### PR TITLE
Fix: restore @egen as SPECIAL_TOKEN to fix comment parsing regression

### DIFF
--- a/src/main/javacc/JavaCC.jj
+++ b/src/main/javacc/JavaCC.jj
@@ -280,21 +280,10 @@ SPECIAL_TOKEN :
 | "\r"
 | "\f"
 | "\u001a"
-}
-
-/* JJTREE CODE */
-
-MORE :
-{
-  "/*@egen*/"        : AFTER_EGEN
+| "/*@egen*/"        : AFTER_EGEN
 | "/*@egen-0l*/"     : AFTER_EGEN_0L
 | "/*@egen-1l*/\n"   : AFTER_EGEN_1L
 | "/*@egen-1l*/\r\n" : AFTER_EGEN_1L
-|
-  "/*@bgen(jjtree)"        { saveBeginLineCol("bgen   ", 0, 0); } : IN_BGEN
-| " /*@bgen-1c(jjtree)"    { saveBeginLineCol("bgen-1c", 0, 1); } : IN_BGEN
-| "\n/*@bgen-1l(jjtree)"   { saveBeginLineCol("bgen-1l", 1, 0); } : IN_BGEN
-| "\r\n/*@bgen-1l(jjtree)" { saveBeginLineCol("bgen-1l", 1, 0); } : IN_BGEN
 }
 
 <AFTER_EGEN>
@@ -315,13 +304,8 @@ SKIP :
   < ~[] > { restoreBeginLineCol("egen-1l", 1, 0); input_stream.backup(1); } : DEFAULT
 }
 
-<IN_BGEN>
-SKIP :
-{
-  "*/" : DEFAULT
-}
-
-/* COMMENTS */
+/* COMMENTS & JJTREE CODE — @bgen patterns must be in the same MORE block as
+ * comment patterns because they share the "/*" prefix. */
 
 MORE :
 {
@@ -332,6 +316,17 @@ MORE :
   : IN_FORMAL_COMMENT
 |
   "/*" : IN_MULTI_LINE_COMMENT
+|
+  "/*@bgen(jjtree)"        { saveBeginLineCol("bgen   ", 0, 0); } : IN_BGEN
+| " /*@bgen-1c(jjtree)"    { saveBeginLineCol("bgen-1c", 0, 1); } : IN_BGEN
+| "\n/*@bgen-1l(jjtree)"   { saveBeginLineCol("bgen-1l", 1, 0); } : IN_BGEN
+| "\r\n/*@bgen-1l(jjtree)" { saveBeginLineCol("bgen-1l", 1, 0); } : IN_BGEN
+}
+
+<IN_BGEN>
+SKIP :
+{
+  "*/" : DEFAULT
 }
 
 <IN_SINGLE_LINE_COMMENT>


### PR DESCRIPTION
Commit 81b04ee moved /*@egen*/ from SPECIAL_TOKEN to a separate MORE block, and moved /*@bgen(jjtree) out of the comments MORE block into that same separate block. This broke parsing of /* and /** comments because the separate MORE block's "/*" prefix interfered with the comment MORE block's NFA — the lexer failed to match "/*" as a comment opener, instead tokenizing "/" as SLASH and "*" as STAR.

Fix: restore the original architecture where @egen variants are SPECIAL_TOKEN (separate NFA, no prefix conflict) and @bgen variants are in the same MORE block as the comment patterns (shared NFA handles the "/*" prefix correctly via longest-match).

The new -1c/-1l/-0l variants from 81b04ee are preserved, just placed in the correct token specification categories.

Fixes comment parsing failure on grammars with /* or /** comments (e.g. JSqlParser with 500+ productions).